### PR TITLE
Handle metrics defaults in prompt manager

### DIFF
--- a/GrokCoreIskra_vΓ/README_vΓ.md
+++ b/GrokCoreIskra_vΓ/README_vΓ.md
@@ -1,1 +1,7 @@
 GrokCoreIskra vΓ — баланс ∆/D/Ω/Λ. Модули: prompt_manager, rag_connector, persona_module, ethics_layer, self_journal.
+
+## Проверка
+
+```bash
+python -m pytest tests/test_grok_prompt_manager.py
+```

--- a/GrokCoreIskra_vΓ/modules/prompt_manager.py
+++ b/GrokCoreIskra_vΓ/modules/prompt_manager.py
@@ -1,5 +1,21 @@
 class PromptManager:
-    def __init__(self): self.prompts={}
-    def add_prompt(self,name,text): self.prompts[name]=text
-    def get_prompt(self,name,metrics): 
-        p=self.prompts.get(name,""); return f"{p} [Metrics: ∆={metrics.get(∆)}, D={metrics.get(D)}]"
+    def __init__(self):
+        self.prompts = {}
+
+    def add_prompt(self, name, text):
+        self.prompts[name] = text
+
+    def get_prompt(self, name, metrics):
+        prompt = self.prompts.get(name, "")
+        metrics = metrics or {}
+
+        delta = metrics.get("∆")
+        d_value = metrics.get("D")
+
+        if delta is None:
+            delta = "N/A"
+
+        if d_value is None:
+            d_value = "N/A"
+
+        return f"{prompt} [Metrics: ∆={delta}, D={d_value}]"

--- a/tests/test_grok_prompt_manager.py
+++ b/tests/test_grok_prompt_manager.py
@@ -1,0 +1,24 @@
+import pytest
+
+from GrokCoreIskra_vΓ.modules.prompt_manager import PromptManager
+
+
+def test_prompt_includes_metrics_values():
+    manager = PromptManager()
+    manager.add_prompt("status", "System ready")
+
+    result = manager.get_prompt("status", {"∆": 1.23, "D": "stable"})
+
+    assert "System ready" in result
+    assert "∆=1.23" in result
+    assert "D=stable" in result
+
+
+def test_prompt_handles_missing_metrics():
+    manager = PromptManager()
+    manager.add_prompt("status", "System ready")
+
+    result = manager.get_prompt("status", {"∆": None})
+
+    assert "∆=N/A" in result
+    assert "D=N/A" in result


### PR DESCRIPTION
## Summary
- ensure `PromptManager` gracefully handles missing metric values by defaulting to `N/A`
- add regression tests covering metric formatting in prompt output
- document how to run the new prompt manager tests

## Testing
- python -m pytest tests/test_grok_prompt_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d58f525b488333abef6ba2a3652e85