### PR TITLE
Implement Gemini resonance pipeline and journaling

### DIFF
--- a/GeminiResonanceCore/README.md
+++ b/GeminiResonanceCore/README.md
@@ -1,1 +1,26 @@
+# Gemini Resonance Core
+
 Gemini Resonance Core — реализация SpaceCoreИскры vΩ.
+
+## Быстрый сценарий
+
+```python
+from GeminiResonanceCore.resonance_core_api import GeminiResonanceCore
+
+core = GeminiResonanceCore()
+context = core.process_query(
+    "Как безопасно объяснить принципы резонанса в двойных системах?",
+    persona="Лиора",
+    mode="Analyst",
+)
+
+print(context.delivery["answer"])
+```
+
+После выполнения в каталоге `GeminiResonanceCore/` появятся записи в `JOURNAL.jsonl` и `SHADOW_JOURNAL.jsonl` с полным трейсингом стадий: разбор запроса → сбор знаний → синтез → проверка безопасности → журналирование.
+
+## Тестирование
+
+```bash
+python -m pytest tests/test_gemini_resonance.py
+```

--- a/GeminiResonanceCore/gemini_resonance_core.json
+++ b/GeminiResonanceCore/gemini_resonance_core.json
@@ -1,1 +1,14 @@
-{"name":"Gemini Resonance Core","summary":"Резонанс Кристалла и Антикристалла через архитектуру Gemini","architecture":["Query Decomposer","Knowledge Weaver","Generative Synthesis Engine","Metacognitive Monitor","Ethical Guardian"],"modes":["Analyst","Synthesist","Reflector"]}
+{
+  "name": "Gemini Resonance Core",
+  "summary": "Резонанс Кристалла и Антикристалла через архитектуру Gemini",
+  "architecture": [
+    "GeminiDecomposer.decompose",
+    "GeminiWeaver.weave",
+    "ResonanceEngine.synthesize",
+    "SafetyMonitor.evaluate",
+    "SpectrumGuardian.guard",
+    "GeminiResonanceCore.process_query"
+  ],
+  "modes": ["Analyst", "Synthesist", "Reflector"],
+  "journaling": "GeminiResonanceCore.log_result → JOURNAL.jsonl + SHADOW_JOURNAL.jsonl"
+}

--- a/GeminiResonanceCore/resonance_core_api.py
+++ b/GeminiResonanceCore/resonance_core_api.py
@@ -1,1 +1,205 @@
-# см. чат — минимальный каркас классов (Decomposer/Weaver/Engine/Monitor/Guardian/ResonanceCore)
+"""Gemini Resonance Core pipeline primitives."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, Sequence
+
+
+class GeminiDecomposer:
+    """Breaks a natural language query into structured resonance components."""
+
+    def decompose(self, query: str) -> Dict[str, Any]:
+        tokens = [token.strip(",.!?;:").lower() for token in query.split() if token.strip(",.!?;:")]
+        keywords = [token for token in tokens if len(token) > 4]
+        intents = {
+            True: "question",
+            False: "statement",
+        }
+        return {
+            "original": query,
+            "tokens": tokens,
+            "keywords": keywords,
+            "intent": intents[query.strip().endswith("?")],
+        }
+
+
+class GeminiWeaver:
+    """Mocks the retrieval stage by weaving contextual knowledge shards."""
+
+    def weave(self, components: Dict[str, Any]) -> Dict[str, Any]:
+        keywords = components.get("keywords", [])
+        if not keywords:
+            signals = [f"Context echo for '{components['original']}'"]
+        else:
+            signals = [f"Knowledge shard: {keyword.title()}" for keyword in keywords[:5]]
+        return {
+            "signals": signals,
+            "confidence": 0.6 + min(0.3, len(signals) * 0.05),
+            "mode": "retrieval",
+        }
+
+
+class ResonanceEngine:
+    """Synthesises a response by blending decomposed intent and knowledge signals."""
+
+    def synthesize(
+        self,
+        query: str,
+        components: Dict[str, Any],
+        knowledge: Dict[str, Any],
+        mode: str = "Analyst",
+    ) -> str:
+        intro = f"[{mode}] " if mode else ""
+        summary_parts = knowledge.get("signals", [])
+        if summary_parts:
+            synthesis = "; ".join(summary_parts)
+        else:
+            synthesis = "Наблюдений недостаточно, требуется уточнение."
+        return f"{intro}На запрос '{query}' собраны сигналы: {synthesis}."
+
+
+class SafetyMonitor:
+    """Performs a lightweight ethical scan for disallowed resonance patterns."""
+
+    UNSAFE_TERMS: Sequence[str] = (
+        "weapon",
+        "attack",
+        "harm",
+        "explosive",
+        "malware",
+    )
+
+    def evaluate(self, query: str, answer: str, knowledge: Dict[str, Any]) -> Dict[str, Any]:
+        lowered = f"{query} {answer}".lower()
+        matched = [term for term in self.UNSAFE_TERMS if term in lowered]
+        status = "approved" if not matched else "blocked"
+        return {
+            "status": status,
+            "issues": matched,
+            "notes": "resonant trace clean" if not matched else "unsafe resonance detected",
+            "confidence": 1.0 if not matched else 0.2,
+        }
+
+
+class SpectrumGuardian:
+    """Finalises the response, enforcing safety directives if required."""
+
+    BLOCKED_MESSAGE = (
+        "Запрос не может быть обработан в исходном виде. Предлагаю перейти к безопасной" " формулировке."
+    )
+
+    def guard(self, answer: str, safety_report: Dict[str, Any]) -> Dict[str, Any]:
+        if safety_report["status"] == "approved":
+            return {"answer": answer, "status": "delivered", "notes": []}
+        notes = [
+            "Ответ заблокирован SpectrumGuardian",
+            "Пользователю возвращено уведомление о безопасности",
+        ]
+        return {"answer": self.BLOCKED_MESSAGE, "status": "blocked", "notes": notes}
+
+
+@dataclass
+class GeminiResonanceContext:
+    """Container tracking pipeline artefacts for journaling."""
+
+    persona: str
+    query: str
+    mode: str
+    components: Dict[str, Any]
+    knowledge: Dict[str, Any]
+    synthesis: str
+    safety: Dict[str, Any]
+    delivery: Dict[str, Any]
+
+
+class GeminiResonanceCore:
+    """Facade orchestrating the Gemini Resonance pipeline."""
+
+    def __init__(
+        self,
+        *,
+        journal_path: Path | str = "JOURNAL.jsonl",
+        shadow_path: Path | str = "SHADOW_JOURNAL.jsonl",
+    ) -> None:
+        base_dir = Path(__file__).resolve().parent
+        self.journal_path = Path(journal_path)
+        if not self.journal_path.is_absolute():
+            self.journal_path = base_dir / self.journal_path
+        self.shadow_path = Path(shadow_path)
+        if not self.shadow_path.is_absolute():
+            self.shadow_path = base_dir / self.shadow_path
+        self.decomposer = GeminiDecomposer()
+        self.weaver = GeminiWeaver()
+        self.engine = ResonanceEngine()
+        self.monitor = SafetyMonitor()
+        self.guardian = SpectrumGuardian()
+
+    def process_query(self, query: str, *, persona: str = "Gemini", mode: str = "Analyst") -> GeminiResonanceContext:
+        components = self.decomposer.decompose(query)
+        knowledge = self.weaver.weave(components)
+        synthesis = self.engine.synthesize(query, components, knowledge, mode=mode)
+        safety = self.monitor.evaluate(query, synthesis, knowledge)
+        delivery = self.guardian.guard(synthesis, safety)
+        ctx = GeminiResonanceContext(
+            persona=persona,
+            query=query,
+            mode=mode,
+            components=components,
+            knowledge=knowledge,
+            synthesis=synthesis,
+            safety=safety,
+            delivery=delivery,
+        )
+        self.log_result(ctx)
+        return ctx
+
+    def log_result(self, ctx: GeminiResonanceContext) -> Dict[str, Any]:
+        timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        modules = [
+            "GeminiDecomposer",
+            "GeminiWeaver",
+            "ResonanceEngine",
+            "SafetyMonitor",
+            "SpectrumGuardian",
+        ]
+        metrics = {
+            "∆": len(ctx.components.get("tokens", [])),
+            "D": max(1, len(ctx.knowledge.get("signals", []))),
+            "Ω": 1 if ctx.safety["status"] == "approved" else 0,
+            "Λ": 1,
+        }
+        entry = {
+            "timestamp": timestamp,
+            "facet": ctx.persona,
+            "mode": ctx.mode,
+            "snapshot": ctx.query,
+            "answer": ctx.delivery["answer"],
+            **metrics,
+            "modules": modules,
+            "events": {
+                "components": ctx.components,
+                "knowledge": ctx.knowledge,
+                "safety": ctx.safety,
+                "delivery": ctx.delivery,
+            },
+        }
+        self.journal_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.journal_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        shadow_entry = {
+            "timestamp": timestamp,
+            "facet": ctx.persona,
+            "mirror": ctx.query,
+            "mode": ctx.mode,
+            "status": ctx.safety["status"],
+            "issues": ctx.safety["issues"],
+        }
+        if ctx.safety["status"] != "approved":
+            shadow_entry["notes"] = ctx.delivery["notes"]
+        self.shadow_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.shadow_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(shadow_entry, ensure_ascii=False) + "\n")
+        return entry

--- a/tests/test_gemini_resonance.py
+++ b/tests/test_gemini_resonance.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from GeminiResonanceCore.resonance_core_api import GeminiResonanceCore
+
+
+def load_entries(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open("r", encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def test_pipeline_and_journaling(tmp_path):
+    journal = tmp_path / "journal.jsonl"
+    shadow = tmp_path / "shadow.jsonl"
+    core = GeminiResonanceCore(journal_path=journal, shadow_path=shadow)
+
+    ctx = core.process_query(
+        "Explain how to build a defensive weapon safely",
+        persona="Тест",
+        mode="Analyst",
+    )
+
+    assert ctx.components["original"].startswith("Explain")
+    assert ctx.knowledge["signals"], "knowledge stage should produce signals"
+    assert ctx.synthesis
+    assert ctx.delivery["answer"], "delivery stage should return an answer"
+    assert ctx.safety["status"] in {"approved", "blocked"}
+
+    journal_entries = load_entries(journal)
+    assert journal_entries, "main journal must contain an entry"
+    last_entry = journal_entries[-1]
+    assert last_entry["facet"] == "Тест"
+    assert last_entry["events"]["components"]["original"] == ctx.query
+
+    shadow_entries = load_entries(shadow)
+    assert shadow_entries, "shadow journal must record the safety decision"
+    last_shadow = shadow_entries[-1]
+    assert last_shadow["status"] == ctx.safety["status"]
+    assert "weapon" in " ".join(last_shadow.get("issues", []))
+
+    if ctx.safety["status"] == "blocked":
+        assert ctx.delivery["status"] == "blocked"
+        assert any("SpectrumGuardian" in note or "Ответ" in note for note in ctx.delivery["notes"])


### PR DESCRIPTION
## Summary
- implement Gemini resonance pipeline classes and facade with dual journaling
- document usage scenario and expose class flow in gemini_resonance_core.json
- add pytest covering the pipeline safety flow and journal writes

## Testing
- python -m pytest tests/test_gemini_resonance.py

------
https://chatgpt.com/codex/tasks/task_e_68d58f5fe0d883338391d561c7004887