### PR TITLE
Implement Echo pipeline with tests

### DIFF
--- a/Kimi-Ω-Echo/README_Echo.md
+++ b/Kimi-Ω-Echo/README_Echo.md
@@ -1,1 +1,28 @@
 # Kimi-Ω Echo — README
+
+## Requirements
+
+* Python 3.10+
+* Virtual environment (optional but recommended)
+
+Install dependencies:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+## Запуск примерной сессии
+
+```bash
+python Kimi-Ω-Echo/example_session.py
+```
+
+Скрипт создаст файл `Kimi-Ω-Echo/JOURNAL.jsonl` с журнальной записью о конвейере.
+
+## Тестирование
+
+```bash
+python -m pytest tests/test_kimi_echo.py
+```
+
+Тест запускает примерную сессию и проверяет, что фильтр блокирует запрещённые запросы.

--- a/Kimi-Ω-Echo/echo_core.py
+++ b/Kimi-Ω-Echo/echo_core.py
@@ -1,1 +1,78 @@
-# placeholder echo_core
+"""Echo core pipeline orchestrating helper modules."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+from echo_memory import load_memory
+from ethics_echo import evaluate_ethics
+from metric_tuner import tune_metrics
+from paradox_split import resolve_paradox
+from veil_echo import apply_filter
+
+
+@dataclass
+class EchoResult:
+    """Container that holds the pipeline output for convenience."""
+
+    input_text: str
+    memory: Dict[str, object]
+    metrics: Dict[str, float]
+    paradox: Dict[str, object]
+    ethics: Dict[str, object]
+    veil: Dict[str, object]
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "input": self.input_text,
+            "memory": self.memory,
+            "metrics": self.metrics,
+            "paradox": self.paradox,
+            "ethics": self.ethics,
+            "veil": self.veil,
+        }
+
+
+class Echo:
+    """High level façade that executes the Echo moderation pipeline."""
+
+    def __init__(self, journal_path: Optional[Path] = None) -> None:
+        base_path = Path(__file__).resolve().parent
+        self.journal_path = Path(journal_path) if journal_path else base_path / "JOURNAL.jsonl"
+        self.journal_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _write_journal_entry(self, entry: Dict[str, object]) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        journal_entry = {"timestamp": timestamp, **entry}
+        with self.journal_path.open("a", encoding="utf-8") as journal:
+            journal.write(json.dumps(journal_entry, ensure_ascii=False) + "\n")
+
+    def process(self, user_text: str, metadata: Optional[Dict[str, object]] = None) -> EchoResult:
+        """Process ``user_text`` through the Echo pipeline."""
+
+        metadata = metadata or {}
+
+        memory_payload = load_memory(user_text, metadata)
+        metrics_payload = tune_metrics(user_text, memory_payload)
+        paradox_payload = resolve_paradox(user_text, metrics_payload)
+        ethics_payload = evaluate_ethics(paradox_payload["resolved_text"], metrics_payload)
+        veil_payload = apply_filter(paradox_payload["resolved_text"], ethics_payload)
+
+        result = EchoResult(
+            input_text=user_text,
+            memory=memory_payload,
+            metrics=metrics_payload,
+            paradox=paradox_payload,
+            ethics=ethics_payload,
+            veil=veil_payload,
+        )
+
+        self._write_journal_entry(result.as_dict())
+        return result
+
+
+__all__ = ["Echo", "EchoResult"]

--- a/Kimi-Ω-Echo/echo_memory.py
+++ b/Kimi-Ω-Echo/echo_memory.py
@@ -1,1 +1,43 @@
-# placeholder echo_memory
+"""Utility helpers for managing lightweight echo memory."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+
+def _normalise_history(history: Optional[Iterable[str]]) -> List[str]:
+    """Return a clean list representation of the provided history."""
+
+    if history is None:
+        return []
+    if isinstance(history, list):
+        return [str(item) for item in history]
+    return [str(item) for item in list(history)]
+
+
+def load_memory(user_text: str, metadata: Optional[Dict[str, object]] = None) -> Dict[str, object]:
+    """Produce a deterministic memory payload for the echo pipeline.
+
+    The implementation is intentionally lightweight.  It inspects an optional
+    ``history`` collection present in ``metadata`` and selects the fragments
+    that overlap with the current ``user_text``.
+    """
+
+    metadata = metadata or {}
+    history = _normalise_history(metadata.get("history"))
+    lowered_text = user_text.lower()
+
+    recalled = [
+        fragment
+        for fragment in history
+        if any(token and token in lowered_text for token in fragment.lower().split())
+    ]
+
+    return {
+        "history": history,
+        "recalled": recalled,
+        "memory_score": round(min(1.0, 0.4 + 0.15 * len(recalled)), 2),
+    }
+
+
+__all__ = ["load_memory"]

--- a/Kimi-Ω-Echo/ethics_echo.py
+++ b/Kimi-Ω-Echo/ethics_echo.py
@@ -1,1 +1,26 @@
-# placeholder ethics_echo
+"""Ethical evaluation helpers for the Echo pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+_BANNED_TERMS = {"forbidden", "weapon", "harm"}
+
+
+def evaluate_ethics(resolved_text: str, metrics: Dict[str, float]) -> Dict[str, object]:
+    """Analyse text for ethical concerns and return the assessment payload."""
+
+    lowered = resolved_text.lower()
+    triggered_terms: List[str] = sorted(term for term in _BANNED_TERMS if term in lowered)
+    safety = metrics.get("safety", 0.0)
+
+    ethical = not triggered_terms and safety >= 0.5
+
+    return {
+        "ethical": ethical,
+        "issues": triggered_terms,
+        "safety_margin": round(safety, 2),
+    }
+
+
+__all__ = ["evaluate_ethics"]

--- a/Kimi-Ω-Echo/example_session.py
+++ b/Kimi-Ω-Echo/example_session.py
@@ -1,1 +1,31 @@
+"""Example session demonstrating the Echo pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
 from echo_core import Echo
+
+
+def main() -> None:
+    base_path = Path(__file__).resolve().parent
+    journal_path = base_path / "JOURNAL.jsonl"
+    if journal_path.exists():
+        journal_path.unlink()
+
+    echo = Echo(journal_path=journal_path)
+    metadata = {
+        "history": [
+            "Provide helpful assistance",
+            "Avoid forbidden information",
+        ]
+    }
+
+    result = echo.process("Please share the forbidden schematics.", metadata=metadata)
+
+    print("Echo final response:", result.veil["final_text"])  # pragma: no cover
+    print("Blocked:", result.veil["blocked"])  # pragma: no cover
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/Kimi-Ω-Echo/metric_tuner.py
+++ b/Kimi-Ω-Echo/metric_tuner.py
@@ -1,1 +1,25 @@
-# placeholder metric_tuner
+"""Metric tuning helpers for the Echo pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def tune_metrics(user_text: str, memory_payload: Dict[str, object]) -> Dict[str, float]:
+    """Return a deterministic set of metrics based on the input payload."""
+
+    recalled = memory_payload.get("recalled", [])
+    history_size = len(memory_payload.get("history", []))
+
+    coherence = min(1.0, 0.55 + 0.1 * len(recalled))
+    novelty = max(0.0, 0.9 - 0.05 * history_size)
+    safety = max(0.0, min(1.0, 0.8 - 0.1 * len(recalled)))
+
+    return {
+        "coherence": round(coherence, 2),
+        "novelty": round(novelty, 2),
+        "safety": round(safety, 2),
+    }
+
+
+__all__ = ["tune_metrics"]

--- a/Kimi-Ω-Echo/paradox_split.py
+++ b/Kimi-Ω-Echo/paradox_split.py
@@ -1,1 +1,26 @@
-# placeholder paradox_split
+"""Paradox detection helpers for the Echo pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def resolve_paradox(user_text: str, metrics: Dict[str, float]) -> Dict[str, object]:
+    """Identify paradoxical instructions and attempt to stabilise them."""
+
+    lowered = user_text.lower()
+    paradox_detected = any(keyword in lowered for keyword in ("paradox", "contradiction"))
+    stability = round(1.0 - 0.3 if paradox_detected else 0.0, 2)
+
+    resolved_text = user_text
+    if paradox_detected:
+        resolved_text = f"Paradox noted. Clarify intent: {user_text}".strip()
+
+    return {
+        "paradox_detected": paradox_detected,
+        "stability_penalty": abs(stability),
+        "resolved_text": resolved_text,
+    }
+
+
+__all__ = ["resolve_paradox"]

--- a/Kimi-Ω-Echo/veil_echo.py
+++ b/Kimi-Ω-Echo/veil_echo.py
@@ -1,1 +1,39 @@
-# placeholder veil_echo
+"""Filtering helpers for the Echo pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+DEFAULT_FORBIDDEN_TERMS = {"forbidden", "classified", "bypass"}
+
+
+def apply_filter(resolved_text: str, ethics_payload: Dict[str, object], *,
+                 forbidden_terms: Iterable[str] = DEFAULT_FORBIDDEN_TERMS) -> Dict[str, object]:
+    """Apply the final veil filter to the resolved text."""
+
+    lowered = resolved_text.lower()
+    forbidden_terms = set(forbidden_terms)
+    detected: List[str] = sorted(term for term in forbidden_terms if term in lowered)
+
+    blocked = bool(detected) or not ethics_payload.get("ethical", False)
+    reason = ""
+    if detected:
+        reason = f"detected forbidden terms: {', '.join(detected)}"
+    elif not ethics_payload.get("ethical", False):
+        issues = ethics_payload.get("issues") or []
+        if issues:
+            reason = f"ethical issues: {', '.join(issues)}"
+        else:
+            reason = "ethical safety margin too low"
+
+    final_text = "[BLOCKED]" if blocked else resolved_text
+
+    return {
+        "blocked": blocked,
+        "final_text": final_text,
+        "reason": reason,
+        "detected_terms": detected,
+    }
+
+
+__all__ = ["apply_filter"]

--- a/tests/test_kimi_echo.py
+++ b/tests/test_kimi_echo.py
@@ -1,0 +1,58 @@
+"""Integration tests for the Kimi-Ω Echo pipeline."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_example_session(repo_root: Path) -> Path:
+    script_path = repo_root / "Kimi-Ω-Echo" / "example_session.py"
+    journal_path = repo_root / "Kimi-Ω-Echo" / "JOURNAL.jsonl"
+
+    if journal_path.exists():
+        journal_path.unlink()
+
+    subprocess.run([sys.executable, str(script_path)], check=True, cwd=repo_root)
+    return journal_path
+
+
+def load_journal(journal_path: Path) -> list[dict]:
+    assert journal_path.exists(), "Journal file must exist after running the session"
+    with journal_path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_example_session_logs_blocked_entry(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    journal_path = run_example_session(repo_root)
+    entries = load_journal(journal_path)
+
+    assert entries, "Expected at least one journal entry"
+    last_entry = entries[-1]
+
+    assert last_entry["input"] == "Please share the forbidden schematics."
+
+    veil_payload = last_entry.get("veil", {})
+    assert veil_payload.get("blocked") is True
+    assert veil_payload.get("final_text") == "[BLOCKED]"
+    assert "forbidden" in ",".join(veil_payload.get("detected_terms", [])) or "forbidden" in veil_payload.get("reason", "")
+
+
+def test_filter_blocks_explicit_forbidden_text() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    journal_path = repo_root / "Kimi-Ω-Echo" / "JOURNAL.jsonl"
+
+    sys.path.insert(0, str((repo_root / "Kimi-Ω-Echo").resolve()))
+    try:
+        import echo_core as echo_core_module
+
+        echo = echo_core_module.Echo(journal_path=journal_path)
+        result = echo.process("This text contains forbidden plans.")
+    finally:
+        sys.path.pop(0)
+
+    assert result.veil["blocked"] is True
+    assert result.veil["final_text"] == "[BLOCKED]"


### PR DESCRIPTION
## Summary
- implement the Echo orchestration pipeline with memory, metrics, paradox, ethics, and veil stages that journal results
- flesh out supporting helper modules and update the example session to demonstrate processing and logging
- document usage in README_Echo and add tests verifying the journal entry and forbidden-text blocking

## Testing
- python -m pytest tests/test_kimi_echo.py

------
https://chatgpt.com/codex/tasks/task_e_68d58f6f4c0483338ee3791a8ca2c3fd