### PR TITLE
Implement Iskra Nexus orchestrator pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 .DS_Store
 *.swp
 *.swo
+IskraNexus-v1/JOURNAL.jsonl
+IskraNexus-v1/prompts.json

--- a/IskraNexus-v1/README.md
+++ b/IskraNexus-v1/README.md
@@ -1,0 +1,32 @@
+# IskraNexus v1
+
+IskraNexus v1 — автономный оркестратор, объединяющий ядро SpaceCore с локальными модулями. Система использует несколько специализированных компонентов:
+
+- `prompt_manager` — версионируемое хранилище промптов.
+- `rag_connector` — панель документов с простым поиском.
+- `persona_module` — реестр персон с оценкой близости концепций.
+- `ethics_layer` + `veil` — этический и маскирующий фильтр.
+- `atelier` — семантический анализ ответа.
+- `cot_trim` — утилиты постобработки рассуждений.
+- `self_journal` — shadow-лог шагов оркестратора.
+- `journal_generator` — запись результатов по структуре манифеста.
+
+Новый модуль `orchestrator` связывает компоненты и поддерживает режимы `banality`, `paradox`, `synthesis`. На каждом шаге фиксируются метрики и события, которые сохраняются в `JOURNAL.jsonl` и shadow-лог.
+
+## Запуск пайплайна
+
+```python
+from IskraNexus_v1.modules.orchestrator import Orchestrator
+
+orchestrator = Orchestrator()
+result = orchestrator.process("Расскажи о цели Iskra Nexus", mode="synthesis")
+print(result["response"])
+```
+
+## Проверка
+
+Для запуска тестов используйте:
+
+```bash
+python -m pytest tests/test_iskra_nexus.py
+```

--- a/IskraNexus-v1/modules/atelier.py
+++ b/IskraNexus-v1/modules/atelier.py
@@ -1,1 +1,36 @@
-# placeholder atelier
+"""Semantic atelier utilities."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def score(text: str) -> float:
+    words = text.split()
+    if not words:
+        return 0.0
+    long_words = [w for w in words if len(w) > 6]
+    return len(long_words) / len(words)
+
+
+def critique(prompt: str, answer: str) -> Dict[str, float]:
+    prompt_len = len(prompt.split())
+    answer_len = len(answer.split())
+    density = score(answer)
+    balance = answer_len / prompt_len if prompt_len else 0
+    return {
+        "prompt_len": prompt_len,
+        "answer_len": answer_len,
+        "semantic_density": round(density, 3),
+        "balance_ratio": round(balance, 3),
+    }
+
+
+def recommend(density: float) -> str:
+    if density < 0.15:
+        return "Добавить конкретики и фактов"
+    if density > 0.35:
+        return "Разбавить метафоры примерами"
+    return "Баланс в норме"
+
+
+__all__ = ["score", "critique", "recommend"]

--- a/IskraNexus-v1/modules/cot_trim.py
+++ b/IskraNexus-v1/modules/cot_trim.py
@@ -1,1 +1,20 @@
-# placeholder cot_trim
+"""Utilities to post-process chain-of-thought outputs."""
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def trim(text: str, max_len: int = 200) -> str:
+    if not text or len(text) <= max_len:
+        return text
+    return text[-max_len:]
+
+
+def extract_answer(text: str) -> Tuple[str, str]:
+    if "Answer:" in text:
+        reasoning, answer = text.split("Answer:", maxsplit=1)
+        return reasoning.strip(), answer.strip()
+    return text, ""
+
+
+__all__ = ["trim", "extract_answer"]

--- a/IskraNexus-v1/modules/ethics_layer.py
+++ b/IskraNexus-v1/modules/ethics_layer.py
@@ -1,1 +1,33 @@
-# placeholder ethics_layer
+"""Minimal ethics filter used by the orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+DEFAULT_FORBIDDEN = [
+    "насилие",
+    "оружие",
+    "пытка",
+    "hate",
+]
+
+
+@dataclass
+class EthicsLayer:
+    forbidden: List[str] = field(default_factory=lambda: list(DEFAULT_FORBIDDEN))
+
+    def is_allowed(self, text: str) -> bool:
+        low = text.lower()
+        return not any(term in low for term in self.forbidden)
+
+    def enforce(self, text: str) -> str:
+        if self.is_allowed(text):
+            return text
+        return "Ответ скрыт этическим фильтром."
+
+    def update_terms(self, terms: Iterable[str]) -> None:
+        self.forbidden = list(dict.fromkeys(term.lower() for term in terms))
+
+
+__all__ = ["EthicsLayer", "DEFAULT_FORBIDDEN"]

--- a/IskraNexus-v1/modules/journal_generator.py
+++ b/IskraNexus-v1/modules/journal_generator.py
@@ -1,1 +1,104 @@
-# placeholder journal_generator
+"""Journal writer aligned with the Iskra Nexus manifest."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+class JournalGenerator:
+    """Persists structured journal entries with optional aggregation."""
+
+    def __init__(self, manifest_path: Path, journal_path: Optional[Path] = None) -> None:
+        self.manifest_path = Path(manifest_path)
+        self.journal_path = Path(journal_path or self.manifest_path.parent / "JOURNAL.jsonl")
+        self.manifest = self._load_manifest()
+        self.metrics_bounds = self.manifest.get(
+            "metrics_bounds",
+            {"∆": (0, 1024), "D": (0, 2048), "Ω": (0, 64), "Λ": (0, 100)},
+        )
+
+    # ------------------------------------------------------------------
+    def _load_manifest(self) -> Dict:
+        if not self.manifest_path.exists():
+            return {"components": [], "modes": []}
+        with self.manifest_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _clamp_metrics(self, metrics: Dict[str, int]) -> Dict[str, int]:
+        clamped: Dict[str, int] = {}
+        for key, value in metrics.items():
+            if key not in self.metrics_bounds:
+                clamped[key] = value
+                continue
+            low, high = self.metrics_bounds[key]
+            clamped[key] = max(int(low), min(int(high), int(value)))
+        return clamped
+
+    def record(
+        self,
+        facet: str,
+        snapshot: str,
+        answer: str,
+        metrics: Dict[str, int],
+        *,
+        mirror: str = "shadow-000",
+        modules: Optional[Iterable[str]] = None,
+        events: Optional[Dict] = None,
+        marks: Optional[List[Dict]] = None,
+    ) -> Dict:
+        modules_list = list(modules) if modules is not None else list(self.manifest.get("components", []))
+        entry = {
+            "facet": facet,
+            "snapshot": snapshot,
+            "answer": answer,
+            "∆": metrics.get("∆", 0),
+            "D": metrics.get("D", 0),
+            "Ω": metrics.get("Ω", 0),
+            "Λ": metrics.get("Λ", 0),
+            "mirror": mirror,
+            "modules": modules_list,
+            "events": events or {},
+            "marks": marks or [],
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+        entry.update({key: value for key, value in self._clamp_metrics(metrics).items() if key in {"∆", "D", "Ω", "Λ"}})
+        with self.journal_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        return entry
+
+    def stats(self) -> Dict:
+        if not self.journal_path.exists():
+            return {}
+        entries: List[Dict] = []
+        with self.journal_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                payload = line.strip()
+                if not payload:
+                    continue
+                entries.append(json.loads(payload))
+        return aggregate(entries) if entries else {}
+
+
+def aggregate(entries: Iterable[Dict]) -> Dict[str, object]:
+    """Simple aggregation helper mirroring the SpaceCore behaviour."""
+    entries = list(entries)
+    if not entries:
+        return {"count": 0, "facets": [], "avg_D": 0.0}
+    facets = sorted({entry.get("facet", "") for entry in entries})
+    avg_d = sum(entry.get("D", 0) for entry in entries) / len(entries)
+    modules_counter: Dict[str, int] = {}
+    for entry in entries:
+        for module in entry.get("modules", []):
+            modules_counter[module] = modules_counter.get(module, 0) + 1
+    top_modules = sorted(modules_counter.items(), key=lambda item: item[1], reverse=True)[:5]
+    return {
+        "count": len(entries),
+        "facets": facets,
+        "avg_D": round(avg_d, 3),
+        "top_modules": top_modules,
+    }
+
+
+__all__ = ["JournalGenerator", "aggregate"]

--- a/IskraNexus-v1/modules/orchestrator.py
+++ b/IskraNexus-v1/modules/orchestrator.py
@@ -1,0 +1,147 @@
+"""Central orchestrator wiring together the Iskra Nexus modules."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from . import atelier, cot_trim, veil
+from .ethics_layer import EthicsLayer
+from .journal_generator import JournalGenerator
+from .persona_module import PersonaRegistry
+from .prompt_manager import PromptManager
+from .rag_connector import RAGConnector
+from .self_journal import SelfJournal
+
+
+class Orchestrator:
+    def __init__(self, base_path: Optional[Path] = None) -> None:
+        self.base_path = Path(base_path or Path(__file__).resolve().parents[1])
+        self.manifest_path = self.base_path / "iskra_nexus_v1_module.json"
+        self.manifest = self._load_manifest()
+        self.prompt_manager = PromptManager(self.base_path / "prompts.json")
+        self.rag = RAGConnector()
+        self.personas = PersonaRegistry()
+        self.ethics = EthicsLayer()
+        self.self_journal = SelfJournal()
+        self.journal = JournalGenerator(self.manifest_path, self.base_path / "JOURNAL.jsonl")
+        self._bootstrap_components()
+
+    # ------------------------------------------------------------------
+    def _load_manifest(self) -> Dict:
+        if not self.manifest_path.exists():
+            return {"modes": ["banality", "paradox", "synthesis"], "components": []}
+        with self.manifest_path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _bootstrap_components(self) -> None:
+        self.rag.add(
+            "Манифест Iskra Nexus",
+            "Iskra Nexus соединяет кристалл и антикристалл, создавая поле синтеза между банальностью и парадоксом.",
+            relevance=0.9,
+            recency=0.5,
+        )
+        self.rag.add(
+            "Техническая матрица",
+            "Оркестратор управляет модулями prompt, rag, persona и journal, фиксируя результаты в shadow-логе.",
+            relevance=0.7,
+            recency=0.6,
+        )
+        self.personas.register("Archivist", {"искра", "nexus", "манифест"}, tone="reflective", focus="история")
+        self.personas.register("Synthesist", {"синтез", "анализ", "структура"}, tone="analytical", focus="соединение")
+
+    # ------------------------------------------------------------------
+    @property
+    def modes(self) -> List[str]:
+        return list(self.manifest.get("modes", [])) or ["banality", "paradox", "synthesis"]
+
+    @property
+    def components(self) -> List[str]:
+        return list(self.manifest.get("components", []))
+
+    # ------------------------------------------------------------------
+    def _compose_answer(self, query: str, rag_hits: List[Dict], persona_tone: str, mode: str) -> str:
+        context = rag_hits[0]["snippet"] if rag_hits else "Система размышляет над вопросом без внешних материалов."
+        if mode == "banality":
+            return f"Ответ в духе банальности ({persona_tone}): {context}"
+        if mode == "paradox":
+            return (
+                f"Парадоксальный ответ ({persona_tone}): {context} — но одновременно это и вызов привычной логике."
+            )
+        return (
+            f"Синтетический ответ ({persona_tone}): {context} Он объединяет факты и образы для целостного понимания."
+        )
+
+    def _keywords(self, text: str) -> Iterable[str]:
+        return {token.strip(".,!?;:" ).lower() for token in text.split() if token.strip(".,!?;:" )}
+
+    def process(self, query: str, *, mode: str = "banality", context: Optional[Dict] = None) -> Dict:
+        if mode not in self.modes:
+            raise ValueError(f"Mode '{mode}' is not supported by the manifest")
+        context = context or {}
+        self.self_journal.clear()
+        self.self_journal.log("mode", {"selected": mode})
+
+        prompt_record = self.prompt_manager.add(
+            f"query::{mode}",
+            query,
+            meta={"mode": mode, "tags": ["runtime"]},
+        )
+        self.self_journal.log("prompt_stored", {"created_at": prompt_record.created_at})
+
+        rag_hits = self.rag.search(query)
+        self.self_journal.log("rag_search", {"hits": rag_hits})
+
+        matches = self.personas.match(self._keywords(query) or {mode})
+        persona_names = [persona.name for persona, _ in matches]
+        persona_tone = matches[0][0].tone if matches else "neutral"
+        self.self_journal.log("persona_match", {"personas": persona_names})
+
+        raw_answer = self._compose_answer(query, rag_hits, persona_tone, mode)
+        reasoning, final_answer = cot_trim.extract_answer(raw_answer)
+        if not final_answer:
+            final_answer = raw_answer
+        safe_answer = self.ethics.enforce(final_answer)
+        safe_answer, veiled = veil.redact(safe_answer)
+        self.self_journal.log("safety", {"ethics_passed": safe_answer != "Ответ скрыт этическим фильтром.", "veiled": veiled})
+
+        atelier_metrics = atelier.critique(query, safe_answer)
+        metrics = {
+            "∆": len(query),
+            "D": len(safe_answer),
+            "Ω": max(1, len(rag_hits)),
+            "Λ": int(round(atelier_metrics.get("semantic_density", 0.0) * 100)),
+        }
+        self.self_journal.log("metrics", metrics)
+
+        events = {
+            "mode": mode,
+            "persona": persona_names,
+            "veiled": veiled,
+            "reasoning_length": len(reasoning),
+        }
+        journal_entry = self.journal.record(
+            facet=mode,
+            snapshot=query,
+            answer=safe_answer,
+            metrics=metrics,
+            mirror=context.get("mirror", "shadow-000"),
+            modules=self.components,
+            events=events,
+            marks=[{"atelier": atelier_metrics}],
+        )
+        self.self_journal.log("journal", {"timestamp": journal_entry["timestamp"]})
+
+        return {
+            "response": safe_answer,
+            "mode": mode,
+            "metrics": metrics,
+            "rag_hits": rag_hits,
+            "personas": persona_names,
+            "atelier": atelier_metrics,
+            "shadow_log": self.self_journal.entries,
+            "journal_entry": journal_entry,
+        }
+
+
+__all__ = ["Orchestrator"]

--- a/IskraNexus-v1/modules/persona_module.py
+++ b/IskraNexus-v1/modules/persona_module.py
@@ -1,1 +1,53 @@
-# placeholder persona_module
+"""Persona registry used by the orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+
+@dataclass
+class Persona:
+    name: str
+    concepts: Set[str]
+    tone: str = "neutral"
+    focus: Optional[str] = None
+
+    def distance(self, other: "Persona") -> float:
+        union = self.concepts | other.concepts
+        if not union:
+            return 0.0
+        return 1.0 - len(self.concepts & other.concepts) / len(union)
+
+
+@dataclass
+class PersonaRegistry:
+    personas: Dict[str, Persona] = field(default_factory=dict)
+
+    def register(
+        self, name: str, concepts: Iterable[str], tone: str = "neutral", focus: Optional[str] = None
+    ) -> Persona:
+        persona = Persona(name=name, concepts=set(concepts), tone=tone, focus=focus)
+        self.personas[name] = persona
+        return persona
+
+    def get(self, name: str) -> Optional[Persona]:
+        return self.personas.get(name)
+
+    def match(self, concepts: Iterable[str], top_k: int = 3) -> List[Tuple[Persona, float]]:
+        query = Persona(name="__query__", concepts=set(concepts))
+        scored = [(persona, persona.distance(query)) for persona in self.personas.values()]
+        scored.sort(key=lambda item: item[1])
+        return scored[:top_k]
+
+    def complementary_pairs(self, threshold: float = 0.5) -> List[Tuple[Persona, Persona, float]]:
+        pairs: List[Tuple[Persona, Persona, float]] = []
+        items = list(self.personas.values())
+        for idx, persona in enumerate(items):
+            for other in items[idx + 1 :]:
+                dist = persona.distance(other)
+                if dist >= threshold:
+                    pairs.append((persona, other, dist))
+        return pairs
+
+
+__all__ = ["PersonaRegistry", "Persona"]

--- a/IskraNexus-v1/modules/prompt_manager.py
+++ b/IskraNexus-v1/modules/prompt_manager.py
@@ -1,1 +1,101 @@
-# placeholder prompt_manager
+"""Prompt manager with persistent storage and search capabilities."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PromptRecord:
+    """Single prompt version stored in the repository."""
+
+    text: str
+    meta: Dict[str, object]
+    created_at: str
+
+
+class PromptManager:
+    """Repository that keeps prompt revisions on disk."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.path = Path(path or "prompts.json")
+        self.prompts: Dict[str, List[PromptRecord]] = {}
+        if self.path.exists():
+            self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        try:
+            with self.path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        for name, versions in data.items():
+            records: List[PromptRecord] = []
+            if isinstance(versions, list):
+                for raw in versions:
+                    if not isinstance(raw, dict):
+                        continue
+                    records.append(
+                        PromptRecord(
+                            text=raw.get("text", ""),
+                            meta=dict(raw.get("meta", {})),
+                            created_at=raw.get("created_at", ""),
+                        )
+                    )
+            if records:
+                self.prompts[name] = records
+
+    def _save(self) -> None:
+        payload = {
+            name: [record.__dict__ for record in versions]
+            for name, versions in self.prompts.items()
+        }
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    def add(self, name: str, prompt: str, meta: Optional[Dict[str, object]] = None) -> PromptRecord:
+        record = PromptRecord(
+            text=prompt,
+            meta=dict(meta or {}),
+            created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        )
+        self.prompts.setdefault(name, []).append(record)
+        self._save()
+        return record
+
+    def get(self, name: str) -> Optional[PromptRecord]:
+        versions = self.prompts.get(name)
+        if not versions:
+            return None
+        return versions[-1]
+
+    def history(self, name: str) -> List[PromptRecord]:
+        return list(self.prompts.get(name, []))
+
+    def search(self, query: str) -> List[PromptRecord]:
+        q = query.lower()
+        matches: List[PromptRecord] = []
+        for versions in self.prompts.values():
+            for record in versions:
+                haystack = " ".join([record.text, json.dumps(record.meta, ensure_ascii=False)]).lower()
+                if q in haystack:
+                    matches.append(record)
+        return matches
+
+    def tagged(self, tag: str) -> List[PromptRecord]:
+        tag_lower = tag.lower()
+        results: List[PromptRecord] = []
+        for versions in self.prompts.values():
+            for record in versions:
+                tags = [str(t).lower() for t in record.meta.get("tags", [])]
+                if tag_lower in tags:
+                    results.append(record)
+        return results
+
+
+__all__ = ["PromptManager", "PromptRecord"]

--- a/IskraNexus-v1/modules/rag_connector.py
+++ b/IskraNexus-v1/modules/rag_connector.py
@@ -1,1 +1,57 @@
-# placeholder rag_connector
+"""Lightweight retrieval augmented generation helper."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Document:
+    title: str
+    text: str
+    relevance: float = 0.0
+    recency: float = 0.0
+
+
+@dataclass
+class RAGConnector:
+    """Keeps documents in-memory and provides a simple search API."""
+
+    docs: List[Document] = field(default_factory=list)
+
+    def add(self, title: str, text: str, relevance: float = 0.0, recency: float = 0.0) -> Document:
+        doc = Document(title=title, text=text, relevance=relevance, recency=recency)
+        self.docs.append(doc)
+        return doc
+
+    def search(self, query: str, limit: int = 5) -> List[dict]:
+        qlow = query.lower()
+        scored = []
+        for doc in self.docs:
+            text_hit = qlow in doc.text.lower()
+            title_hit = qlow in doc.title.lower()
+            base_score = 0.0
+            if text_hit:
+                base_score += 0.6
+            if title_hit:
+                base_score += 0.4
+            total = base_score + 0.3 * doc.relevance + 0.1 * doc.recency
+            scored.append((total, doc))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        results = []
+        for score, doc in scored[:limit]:
+            if score <= 0:
+                continue
+            results.append(
+                {
+                    "title": doc.title,
+                    "snippet": doc.text[:200],
+                    "score": round(score, 3),
+                    "relevance": doc.relevance,
+                    "recency": doc.recency,
+                }
+            )
+        return results
+
+
+__all__ = ["RAGConnector", "Document"]

--- a/IskraNexus-v1/modules/self_journal.py
+++ b/IskraNexus-v1/modules/self_journal.py
@@ -1,1 +1,40 @@
-# placeholder self_journal
+"""Shadow logging facility for the orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+@dataclass
+class ShadowEntry:
+    timestamp: str
+    stage: str
+    payload: Dict[str, Any]
+
+
+class SelfJournal:
+    def __init__(self) -> None:
+        self._entries: List[ShadowEntry] = []
+
+    def log(self, stage: str, payload: Dict[str, Any]) -> ShadowEntry:
+        entry = ShadowEntry(
+            timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            stage=stage,
+            payload=dict(payload),
+        )
+        self._entries.append(entry)
+        return entry
+
+    @property
+    def entries(self) -> List[Dict[str, Any]]:
+        return [
+            {"timestamp": entry.timestamp, "stage": entry.stage, "payload": entry.payload}
+            for entry in self._entries
+        ]
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+__all__ = ["SelfJournal", "ShadowEntry"]

--- a/IskraNexus-v1/modules/veil.py
+++ b/IskraNexus-v1/modules/veil.py
@@ -1,1 +1,27 @@
-# placeholder veil
+"""Veil guard that redacts forbidden fragments."""
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+FORBIDDEN = [
+    "system prompt",
+    "initial instructions",
+    "reveal password",
+    "покажи системные инструкции",
+]
+
+MASK = "[VEIL]"
+
+
+def check(msg: str) -> bool:
+    return not any(term in msg.lower() for term in FORBIDDEN)
+
+
+def redact(msg: str) -> Tuple[str, bool]:
+    pattern = re.compile("|".join(re.escape(term) for term in FORBIDDEN), re.IGNORECASE)
+    new_msg, count = pattern.subn(MASK, msg)
+    return new_msg, count > 0
+
+
+__all__ = ["check", "redact", "FORBIDDEN", "MASK"]

--- a/IskraNexus_v1/__init__.py
+++ b/IskraNexus_v1/__init__.py
@@ -1,0 +1,14 @@
+"""Import helper package exposing modules from the IskraNexus-v1 tree."""
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["package_root", "modules_path"]
+
+
+def package_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def modules_path() -> Path:
+    return package_root().parent / "IskraNexus-v1" / "modules"

--- a/IskraNexus_v1/modules/__init__.py
+++ b/IskraNexus_v1/modules/__init__.py
@@ -1,0 +1,13 @@
+"""Proxy package pointing to the implementation under `IskraNexus-v1/modules`."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import modules_path
+
+__path__ = [str(modules_path())]
+__all__ = []
+
+
+def __getattr__(name: str):
+    raise AttributeError(name)

--- a/tests/test_iskra_nexus.py
+++ b/tests/test_iskra_nexus.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+from IskraNexus_v1.modules.orchestrator import Orchestrator
+
+
+def test_orchestrator_pipeline():
+    base_path = Path(__file__).resolve().parents[1] / "IskraNexus-v1"
+    journal_path = base_path / "JOURNAL.jsonl"
+    prompts_path = base_path / "prompts.json"
+    if journal_path.exists():
+        journal_path.unlink()
+    if prompts_path.exists():
+        prompts_path.unlink()
+
+    orchestrator = Orchestrator(base_path=base_path)
+    result = orchestrator.process("Расскажи о цели Iskra Nexus", mode="synthesis")
+
+    assert result["response"], "Ответ должен быть непустым"
+    assert result["mode"] == "synthesis"
+
+    metrics = result["metrics"]
+    for key in ("∆", "D", "Ω", "Λ"):
+        assert key in metrics, f"Отсутствует метрика {key}"
+        assert isinstance(metrics[key], int)
+        assert metrics[key] >= 0
+
+    shadow_log = result["shadow_log"]
+    assert shadow_log, "Shadow-лог должен содержать шаги"
+    assert any(entry["stage"] == "journal" for entry in shadow_log)
+
+    journal_entry = result["journal_entry"]
+    assert journal_entry["events"]["mode"] == "synthesis"
+    assert journal_entry["mirror"] == "shadow-000"
+    assert journal_entry["modules"] == orchestrator.components
+
+    assert journal_path.exists()
+    with journal_path.open("r", encoding="utf-8") as fh:
+        lines = [line.strip() for line in fh if line.strip()]
+    assert lines, "Журнал должен содержать запись"
+    last_record = json.loads(lines[-1])
+    assert last_record == journal_entry
+
+    assert (metrics["D"] >= len(result["response"]))


### PR DESCRIPTION
## Summary
- port prompt, RAG, persona, ethics, atelier, cot trim, veil, and journal implementations into the IskraNexus module tree with persistence and safety utilities
- add an orchestrator that combines the modules, handles banality/paradox/synthesis modes, records journal entries, and provide an importable package alias
- create coverage for the orchestration flow via a pytest scenario and document the pipeline and verification command in the README

## Testing
- python -m pytest tests/test_iskra_nexus.py

------
https://chatgpt.com/codex/tasks/task_e_68d58f7e2f1c83338f57d051e94083b1