### PR TITLE
Fix metrics key lookups in prompt manager

### DIFF
--- a/GrokCoreIskra_vΓ/modules/prompt_manager.py
+++ b/GrokCoreIskra_vΓ/modules/prompt_manager.py
@@ -1,5 +1,8 @@
 class PromptManager:
     def __init__(self): self.prompts={}
     def add_prompt(self,name,text): self.prompts[name]=text
-    def get_prompt(self,name,metrics): 
-        p=self.prompts.get(name,""); return f"{p} [Metrics: ∆={metrics.get(∆)}, D={metrics.get(D)}]"
+    def get_prompt(self,name,metrics):
+        p=self.prompts.get(name,"")
+        delta=metrics.get("∆","N/A")
+        distance=metrics.get("D","N/A")
+        return f"{p} [Metrics: ∆={delta}, D={distance}]"


### PR DESCRIPTION
## Summary
- update prompt manager metric lookups to use explicit string keys
- provide default values when metrics are missing to avoid formatting errors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6409695bc8333bf5061043abf2b07