### PR TITLE
Add tests for prompt manager metrics handling

### DIFF
--- a/GrokCoreIskra_vΓ/README_vΓ.md
+++ b/GrokCoreIskra_vΓ/README_vΓ.md
@@ -2,6 +2,8 @@ GrokCoreIskra vΓ — баланс ∆/D/Ω/Λ. Модули: prompt_manager, ra
 
 ## Проверка
 
+Для запуска минимального набора проверок выполните модульные тесты менеджера промптов:
+
 ```bash
 python -m pytest tests/test_grok_prompt_manager.py
 ```

--- a/GrokCoreIskra_vΓ/modules/prompt_manager.py
+++ b/GrokCoreIskra_vΓ/modules/prompt_manager.py
@@ -7,7 +7,11 @@ class PromptManager:
 
     def get_prompt(self, name, metrics):
         prompt = self.prompts.get(name, "")
-        metrics = metrics or {}
+
+        if not isinstance(metrics, dict):
+            metrics = {}
+        else:
+            metrics = metrics or {}
 
         delta = metrics.get("∆")
         d_value = metrics.get("D")

--- a/tests/test_grok_prompt_manager.py
+++ b/tests/test_grok_prompt_manager.py
@@ -3,22 +3,31 @@ import pytest
 from GrokCoreIskra_vΓ.modules.prompt_manager import PromptManager
 
 
-def test_prompt_includes_metrics_values():
+def test_prompt_manager_includes_metrics():
     manager = PromptManager()
-    manager.add_prompt("status", "System ready")
+    manager.add_prompt("status", "System status report")
 
-    result = manager.get_prompt("status", {"∆": 1.23, "D": "stable"})
+    metrics = {"∆": 0.42, "D": 7}
+    prompt_text = manager.get_prompt("status", metrics)
 
-    assert "System ready" in result
-    assert "∆=1.23" in result
-    assert "D=stable" in result
+    assert "System status report" in prompt_text
+    assert "∆=0.42" in prompt_text
+    assert "D=7" in prompt_text
 
 
-def test_prompt_handles_missing_metrics():
+def test_prompt_manager_defaults_missing_metrics():
     manager = PromptManager()
-    manager.add_prompt("status", "System ready")
+    manager.add_prompt("status", "System status report")
 
-    result = manager.get_prompt("status", {"∆": None})
+    prompt_text = manager.get_prompt("status", {})
 
-    assert "∆=N/A" in result
-    assert "D=N/A" in result
+    assert "∆=N/A" in prompt_text
+    assert "D=N/A" in prompt_text
+
+    prompt_text_none = manager.get_prompt("status", None)
+    assert "∆=N/A" in prompt_text_none
+    assert "D=N/A" in prompt_text_none
+
+    prompt_text_invalid = manager.get_prompt("status", [])
+    assert "∆=N/A" in prompt_text_invalid
+    assert "D=N/A" in prompt_text_invalid


### PR DESCRIPTION
## Summary
- ensure `PromptManager` handles missing metrics input gracefully
- add coverage verifying metric inclusion and defaults
- document the pytest command for the Grok prompt manager

## Testing
- python -m pytest tests/test_grok_prompt_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68d79a67025c83338819342a3cc34df6