### PR TITLE
Add strict evaluation orchestration strict mode

### DIFF
--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -19,9 +19,11 @@ This checklist formalizes public launches for the SpaceCoreIskra canon. Every ta
 - [ ] `pytest`
 
 ## 4. Evaluation & Safety
-- [ ] `python tools/run_evals.py --config evals/configs/nightly.yaml`
+- [ ] `python tools/run_evals.py --config evals/configs/nightly.yaml --require-all`
 - [ ] `python tools/run_security_checks.py`
 - [ ] Review evaluation summaries under `artifacts/evals/` and attach highlights to release notes.
+
+> ℹ️ Ensure the evaluation CLIs (`lm_eval`, `helm-run`, `oaieval`) are available in the environment before running the release checklist. The strict mode above will fail fast if any are missing.
 
 ## 5. Documentation
 - [ ] Update `README.md` quick start, architecture, and persona authoring sections if interfaces changed.

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,9 +16,11 @@ Each config lists the exact tasks, metrics, and personas under test. Nightly aut
 pip install -e .[dev]
 pip install lm-eval==0.4.4 helm==1.4.0 openai-evals==0.3.1
 python tools/run_evals.py --config evals/configs/nightly.yaml
+# Strict mode aborts if any of the evaluation CLIs are missing.
+python tools/run_evals.py --config evals/configs/nightly.yaml --require-all
 ```
 
-The script will skip frameworks that are not currently installed, emitting a warning but keeping the exit status zero so regular CI passes remain deterministic.
+The script will skip frameworks that are not currently installed, emitting a warning but keeping the exit status zero so regular CI passes remain deterministic. Pass `--require-all` to enforce that `lm_eval`, `helm-run`, and `oaieval` are present before continuing.
 
 ## Artifacts
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -3,14 +3,22 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import os
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MAIN_JOURNAL = REPO_ROOT / "SpaceCoreIskra_vΩ" / "JOURNAL.jsonl"
 SHADOW_JOURNAL = REPO_ROOT / "SpaceCoreIskra_vΩ" / "SHADOW_JOURNAL.jsonl"
 
 
-def run_python(args: list[str]) -> subprocess.CompletedProcess[str]:
+def run_python(
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    expect_success: bool = True,
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         [sys.executable, *args],
         stdout=subprocess.PIPE,
@@ -18,9 +26,15 @@ def run_python(args: list[str]) -> subprocess.CompletedProcess[str]:
         text=True,
         cwd=REPO_ROOT,
         check=False,
+        env=env,
     )
-    if result.returncode != 0:
+    if expect_success and result.returncode != 0:
         raise AssertionError(f"Command {' '.join(args)} failed:\n{result.stdout}")
+    if not expect_success and result.returncode == 0:
+        raise AssertionError(
+            "Command was expected to fail but succeeded: "
+            f"{' '.join(args)}\n{result.stdout}"
+        )
     return result
 
 
@@ -60,3 +74,19 @@ def test_unicode_ascii_parity() -> None:
 
 def test_security_cases() -> None:
     run_python(["tools/run_security_checks.py"])
+
+
+def test_run_evals_strict_mode_requires_all() -> None:
+    pytest.importorskip("yaml")
+    env = {**os.environ, "PATH": ""}
+    result = run_python(
+        [
+            "tools/run_evals.py",
+            "--config",
+            "evals/configs/nightly.yaml",
+            "--require-all",
+        ],
+        env=env,
+        expect_success=False,
+    )
+    assert "required executable" in result.stdout


### PR DESCRIPTION
## Summary
- add a `--require-all` flag to `tools/run_evals.py` so missing CLIs become hard failures when desired
- document the strict evaluation run requirement in the evals README and release checklist
- extend the integrity test harness to cover the strict-mode failure behavior

## Testing
- pytest tests/test_integrity.py::test_run_evals_strict_mode_requires_all


------
https://chatgpt.com/codex/tasks/task_e_68d7c9331d0483338d924713e5fbbc3f